### PR TITLE
Add missing \r to the response headers

### DIFF
--- a/echo.py
+++ b/echo.py
@@ -47,7 +47,7 @@ def serve(host='0.0.0.0', port=3246, verbosity=1):
                 print(' - '.join([client_address[0], request_time, request['header']['request-line']]))
 
             raw_decoded = request['raw'].decode('utf-8', 'ignore')
-            response = "HTTP/1.1 200 OK\nAccess-Control-Allow-Origin: *\n\n{}".format(raw_decoded)
+            response = "HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\n\r\n{}".format(raw_decoded)
             if verbosity == 2:
                 print("-"*10)
                 print(response)


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc7230#section-3

>   All HTTP/1.1 messages consist of a start-line followed by a sequence
>   of octets in a format similar to the Internet Message Format
>   [RFC5322]: zero or more header fields (collectively referred to as
>   the "headers" or the "header section"), an empty line indicating the
>   end of the header section, and an optional message body.
>
> ```
>     HTTP-message   = start-line
>                      *( header-field CRLF )
>                      CRLF
>                      [ message-body ]
> ```

This causes problems with some clients like docs.rs/surf