### PR TITLE
Add support for OWS in header-fields

### DIFF
--- a/echo.py
+++ b/echo.py
@@ -65,7 +65,9 @@ def build_request(first_chunk):
     h = {'request-line': lines[0]}
     i = 1
     while i < len(lines[1:]) and lines[i] != '':
-        k, v = lines[i].split(': ')
+        k, v = lines[i].split(":", 1)
+        if v[0] == " ":
+            v = v[1:]
         h.update({k.lower(): v})
         i += 1
     r = {


### PR DESCRIPTION
https://www.rfc-editor.org/rfc/rfc7230#section-3.2

>  Each header field consists of a case-insensitive field name followed
>  by a colon (":"), optional leading whitespace, the field value, and
>  optional trailing whitespace.
>
> ```
>     header-field   = field-name ":" OWS field-value OWS
> ```

Before this, the server would crash if the "optional" whitespace was missing.